### PR TITLE
Add async and use_ssl as a configuration options

### DIFF
--- a/lib/ringflux/plugin.rb
+++ b/lib/ringflux/plugin.rb
@@ -11,7 +11,7 @@ class Ringflux::Plugin < Adhearsion::Plugin
     username    nil         , desc: 'InfluxDB username'
     password    nil         , desc: 'InfluxDB password'
     database    'adhearsion', desc: 'host where the message queue is running'
-    async       true        , desc: 'Asynchronously send data to InfluxDB'
+    async       true        , desc: 'Asynchronously send data to InfluxDB', transform: ->(value) { value && value != "false" }
     use_ssl     nil         , desc: 'Connect to InfluxDB using SSL'
     opts        DEFAULT_OPTS, desc: 'Options to pass to the InfluxDB client'
   end

--- a/lib/ringflux/plugin.rb
+++ b/lib/ringflux/plugin.rb
@@ -2,9 +2,7 @@ require 'influxdb'
 require 'countdownlatch'
 
 class Ringflux::Plugin < Adhearsion::Plugin
-  DEFAULT_OPTS = {
-    async: true,
-  }
+  DEFAULT_OPTS = {}
   mattr_reader :connection
 
   # Configure the connection information to your InfluxDB instance.
@@ -13,6 +11,7 @@ class Ringflux::Plugin < Adhearsion::Plugin
     username    nil         , desc: 'InfluxDB username'
     password    nil         , desc: 'InfluxDB password'
     database    'adhearsion', desc: 'host where the message queue is running'
+    async       true        , desc: 'Asynchronously send data to InfluxDB'
     opts        DEFAULT_OPTS, desc: 'Options to pass to the InfluxDB client'
   end
 
@@ -23,7 +22,15 @@ class Ringflux::Plugin < Adhearsion::Plugin
 
   def configure
     logger.info "Configuring InfluxDB #{config.username}@#{config.host} with database #{config.database}"
-    @@connection = InfluxDB::Client.new config.database, config.opts.merge(host: config.host, username: config.username, password: config.password)
+    @@connection = InfluxDB::Client.new(
+      config.database,
+      config.opts.merge(
+        host: config.host,
+        username: config.username,
+        password: config.password,
+        async: config.async
+      )
+    )
   end
 
   def self.write_point(*args)

--- a/lib/ringflux/plugin.rb
+++ b/lib/ringflux/plugin.rb
@@ -12,6 +12,7 @@ class Ringflux::Plugin < Adhearsion::Plugin
     password    nil         , desc: 'InfluxDB password'
     database    'adhearsion', desc: 'host where the message queue is running'
     async       true        , desc: 'Asynchronously send data to InfluxDB'
+    use_ssl     nil         , desc: 'Connect to InfluxDB using SSL'
     opts        DEFAULT_OPTS, desc: 'Options to pass to the InfluxDB client'
   end
 
@@ -28,7 +29,8 @@ class Ringflux::Plugin < Adhearsion::Plugin
         host: config.host,
         username: config.username,
         password: config.password,
-        async: config.async
+        async: config.async,
+        use_ssl: config.use_ssl
       )
     )
   end


### PR DESCRIPTION
Summary
-------

Sometimes, in supporting rake tasks and the like, we want to explicitly configure the "options" of the InfluxDB client. The goal of this PR is to expose the `async` and `use_ssl` options as first-class configuration values of the `Ringflux` client while maintaining backwards compatibility with default values.