### PR TITLE
Fix use_ssl option when set via ENV variable

### DIFF
--- a/lib/ringflux/plugin.rb
+++ b/lib/ringflux/plugin.rb
@@ -12,7 +12,7 @@ class Ringflux::Plugin < Adhearsion::Plugin
     password    nil         , desc: 'InfluxDB password'
     database    'adhearsion', desc: 'host where the message queue is running'
     async       true        , desc: 'Asynchronously send data to InfluxDB', transform: ->(value) { value && value != "false" }
-    use_ssl     nil         , desc: 'Connect to InfluxDB using SSL'
+    use_ssl     nil         , desc: 'Connect to InfluxDB using SSL', transform: ->(value) { value && value != "false" }
     opts        DEFAULT_OPTS, desc: 'Options to pass to the InfluxDB client'
   end
 


### PR DESCRIPTION
Summary
-------

When specifying `AHN_RINGFLUX_USE_SSL=false` the `false` value is
read in as the string `"false"`. When passed to the InfluxDB client,
`"false"` evaluates to a "truthy" value and causes the client to
attempt to use a SSL connection. This adds a value transform so that
when `AHN_RINGFLUX_USE_SSL=false` the InfluxDB client will NOT attempt
to use a SSL connection.