### PR TITLE
Add max retries to influxdb connection

### DIFF
--- a/lib/ringflux/plugin.rb
+++ b/lib/ringflux/plugin.rb
@@ -13,6 +13,7 @@ class Ringflux::Plugin < Adhearsion::Plugin
     database    'adhearsion', desc: 'host where the message queue is running'
     async       true        , desc: 'Asynchronously send data to InfluxDB', transform: ->(value) { value && value != "false" }
     use_ssl     nil         , desc: 'Connect to InfluxDB using SSL', transform: ->(value) { value && value != "false" }
+    retries     3           , desc: 'Number of attempts to make with the InfluxDB client'
     opts        DEFAULT_OPTS, desc: 'Options to pass to the InfluxDB client'
   end
 
@@ -31,7 +32,7 @@ class Ringflux::Plugin < Adhearsion::Plugin
         password: config.password,
         async: config.async,
         use_ssl: config.use_ssl,
-        retry: 3
+        retry: config.retries
       )
     )
   end

--- a/lib/ringflux/plugin.rb
+++ b/lib/ringflux/plugin.rb
@@ -30,7 +30,8 @@ class Ringflux::Plugin < Adhearsion::Plugin
         username: config.username,
         password: config.password,
         async: config.async,
-        use_ssl: config.use_ssl
+        use_ssl: config.use_ssl,
+        retry: 3
       )
     )
   end

--- a/lib/ringflux/plugin.rb
+++ b/lib/ringflux/plugin.rb
@@ -13,7 +13,7 @@ class Ringflux::Plugin < Adhearsion::Plugin
     database    'adhearsion', desc: 'host where the message queue is running'
     async       true        , desc: 'Asynchronously send data to InfluxDB', transform: ->(value) { value && value != "false" }
     use_ssl     nil         , desc: 'Connect to InfluxDB using SSL', transform: ->(value) { value && value != "false" }
-    retries     3           , desc: 'Number of attempts to make with the InfluxDB client'
+    retries     3           , desc: 'Number of attempts to make with the InfluxDB client', transform: ->(value) { value.to_i }
     opts        DEFAULT_OPTS, desc: 'Options to pass to the InfluxDB client'
   end
 


### PR DESCRIPTION
Was trying connection an infinite amount of times. This led to the upload_recordings rake task to never terminate. InfluxDB takes an option to specify retries, PR sets this to 3.

Is this going to conflict with any other usage of InfluxDB throughout TB?