### PR TITLE
Add argument error if write_point values missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 /Gemfile.lock
 /ringflux-*.gem
+/.yardoc
+/doc

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,3 @@
+--no-private
+-
+README.md

--- a/lib/ringflux/plugin.rb
+++ b/lib/ringflux/plugin.rb
@@ -55,8 +55,6 @@ class Ringflux::Plugin < Adhearsion::Plugin
     raise ArgumentError, "Cannot write empty values to series: #{args[0]}" if args[1][:values].empty?
     logger.debug "Sending data to InfluxDB: #{args.inspect}"
     @@connection.write_point(*args)
-  rescue ArgumentError => e
-    logger.error "Cannot write data to InfluxDB: #{e.inspect}"
   end
 
   private

--- a/lib/ringflux/plugin.rb
+++ b/lib/ringflux/plugin.rb
@@ -39,9 +39,24 @@ class Ringflux::Plugin < Adhearsion::Plugin
     )
   end
 
+  #
+  # Write data to InfluxDB client
+  # @overload write_point(series, data, precision = nil, retention_policy = nil, database = nil)
+  #   @param [String] series The name of the series to which to write
+  #   @param [Hash] data The hash of data to send in the payload
+  #     * :values [Hash] values The hash of key value pairs for the series
+  #     * :tags [Hash] tags Optional hash of tags for the data
+  #     * :timestamp [Integer] timestamp Optional epoch timestamp for the data (InfluxDB will default to now)
+  #   @param [String] precision Optional string for time precision
+  #   @param [String] retention_policy Optional string for retention policy
+  #   @param [String] database Optional string to override database
+  #
   def self.write_point(*args)
-    logger.debug "Sending data to  InfluxDB: #{args.inspect}"
+    raise ArgumentError, "Cannot write empty values to series: #{args[0]}" if args[1][:values].empty?
+    logger.debug "Sending data to InfluxDB: #{args.inspect}"
     @@connection.write_point(*args)
+  rescue ArgumentError => e
+    logger.error "Cannot write data to InfluxDB: #{e.inspect}"
   end
 
   private

--- a/ringflux.gemspec
+++ b/ringflux.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency %q<bundler>, ["~> 1.0"]
   s.add_development_dependency %q<rspec>, ["~> 2.5"]
   s.add_development_dependency %q<rake>, [">= 0"]
+  s.add_development_dependency %q<yard>
   s.add_development_dependency %q<guard-rspec>
  end


### PR DESCRIPTION
Raises `ArgumentError` if values is empty, warns in `logger`.

Also beginnings of documentation.